### PR TITLE
Add missing space to cmd in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You are free to use the source code in any project you need or fork the whole bl
 Installation is like normal laravel applications
 
 1. `composer install`
-2. `cp.env.example .env`
+2. `cp .env.example .env`
 3. `php artisan key:generate`
 4. `php artisan migrate`
 5. `npm install`


### PR DESCRIPTION
Small fix in one of the README.md commands used to setup the project.

@bambamboole @jchristlieb 