### PR TITLE
Add expected success flash notification to ContactForm

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -32,7 +32,7 @@ class ContactController extends Controller
         ]);
 
         Mail::send(new ContactForm($data));
-
+        flash('Mail successfully sent')->success();
         return response()->json(['message' => 'Contact form successfully send']);
     }
 }


### PR DESCRIPTION
Fixes failing unit test
```bash
1) Tests\Feature\ContactFormTest::a_contact_mail_gets_sent
Error: Call to a member function first() on null
```

I added the expected success flash notification.

@bambamboole @jchristlieb 