### PR TITLE
Add expected redirect back to /contact if mail was sent successfully

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -33,6 +33,6 @@ class ContactController extends Controller
 
         Mail::send(new ContactForm($data));
 
-        return response()->json(['message' => 'Contact form successfully send']);
+        return redirect()->back();
     }
 }


### PR DESCRIPTION
Fixes failing unit test
```bash
1) Tests\Feature\ContactFormTest::it_redirects_back_after_success
Response status code [200] is not a redirect status code.
Failed asserting that false is true.
```

Added the expected redirect back to /contact if mail was sent successfully.

@bambamboole @jchristlieb 